### PR TITLE
Fix Platform specific KeyboardAvoidingView Behavior

### DIFF
--- a/src/nav/auth/Auth.js
+++ b/src/nav/auth/Auth.js
@@ -24,7 +24,7 @@ class Auth extends React.Component {
     return (
       <KeyboardAvoidingView
       style={styles.container}
-        behavior={Platform.Os == "ios" ? "padding" : "height"}
+        behavior={Platform.OS === 'ios' ? 'height' : 'padding'}
       >
           <Image
             style={styles.logo}


### PR DESCRIPTION

*Issue #, if available:*
N\A

*Description of changes:*
The KeyboardAvoidingView has a typo in the Platform call. Os instead of OS.

I also found that using height on iOS and padding on android worked best. Specifically as-is, the behavior was causing "forgot password" and "sign up" to be pushed on top of each other.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. - So say us all... 
